### PR TITLE
NPM setup & debug mode visualizer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+**/node_modules
+**/main.js

--- a/01/readme.md
+++ b/01/readme.md
@@ -1,0 +1,12 @@
+# Sample code for 'How Readup Knows Whether or Not You’ve Read an Article'
+
+Find the article [here](https://blog.readup.com/2020/11/02/how-readup-knows-whether-or-not-youve-read-an-article.html).
+
+The code here is slightly adjusted compared to the sample exhibits in the article. The only difference is that it visualizes the reading tracker by default (debug mode).
+
+To run the project:
+
+1. `cd` to the `web-client` folder
+2. `npm install`
+3. `npm run start`
+4. Open the server that starts in your browser and click the 'article.html' page

--- a/01/web-client/article.html
+++ b/01/web-client/article.html
@@ -2,11 +2,14 @@
 <html>
 	<head>
 		<title>article</title>
-		<meta name="viewport" content="width=device-width,initial-scale=1,user-scalable=no,viewport-fit=cover" />
+		<meta
+			name="viewport"
+			content="width=device-width,initial-scale=1,user-scalable=no,viewport-fit=cover"
+		/>
 		<script defer src="./main.js"></script>
 		<style>
 			body {
-				width: 320px;
+				max-width: 520px;
 				margin: 0 auto;
 				font-size: 16pt;
 				font-family: sans-serif;
@@ -14,9 +17,117 @@
 		</style>
 	</head>
 	<body>
-		<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Sit amet risus nullam eget.</p>
-		<p>Convallis posuere morbi leo urna molestie at elementum eu facilisis. Fermentum iaculis eu non diam phasellus vestibulum lorem sed. Aliquam malesuada bibendum arcu vitae elementum curabitur vitae nunc sed. Dignissim sodales ut eu sem. Eget gravida cum sociis natoque penatibus et.</p>
-		<p>Eros in cursus turpis massa tincidunt dui ut ornare. Et leo duis ut diam quam nulla porttitor massa id. Diam quis enim lobortis scelerisque fermentum dui faucibus in ornare.</p>
-		<p>Sit amet facilisis magna etiam tempor orci eu. Facilisis mauris sit amet massa vitae tortor condimentum. Imperdiet sed euismod nisi porta. Faucibus in ornare quam viverra orci sagittis.</p>
+		<p>
+			Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi vestibulum
+			imperdiet ligula non congue. Aenean congue rhoncus enim id tempus. Morbi
+			posuere dui felis, dictum elementum lorem posuere vitae. Integer finibus
+			arcu ex, eu accumsan enim gravida sed. Praesent fermentum, augue eu
+			sollicitudin mattis, diam arcu elementum orci, eget rhoncus tortor nibh a
+			mi. Nullam lacus velit, efficitur sed odio tincidunt, cursus consectetur
+			eros. Maecenas a ex tempus, mollis ex nec, malesuada ipsum. Sed eu eros
+			enim. Nullam felis ipsum, commodo quis nisi in, tincidunt bibendum magna.
+			Orci varius natoque penatibus et magnis dis parturient montes, nascetur
+			ridiculus mus. Maecenas varius massa eu porttitor posuere. Donec eu
+			blandit ligula. Suspendisse dictum cursus tortor ut laoreet.
+		</p>
+		<p>
+			Curabitur tristique, nisi a sollicitudin vulputate, nibh elit gravida
+			sapien, at ultricies risus neque quis ligula. Duis imperdiet non nulla a
+			faucibus. Nullam vehicula sollicitudin nisi, feugiat porttitor eros
+			ultrices viverra. Duis congue lectus vel dolor mattis, in pellentesque
+			libero molestie. Vivamus laoreet eros non porttitor eleifend. Quisque
+			consequat odio sed arcu auctor, quis tempus felis commodo. Nulla feugiat
+			mauris ut tellus facilisis, tempus maximus massa volutpat. Proin consequat
+			blandit libero, sit amet efficitur orci pulvinar pretium. Maecenas arcu
+			elit, finibus at eleifend non, tincidunt ac mi.
+		</p>
+		<p>
+			Ut tristique ligula ultricies nulla eleifend, eu ullamcorper est tempor.
+			Aliquam rutrum, nisl eget sagittis commodo, erat ante egestas mi, sit amet
+			eleifend neque dui ac massa. Vivamus sed purus ut arcu elementum
+			scelerisque. Nullam mattis ut massa vel tempor. Pellentesque efficitur
+			lorem arcu, a fringilla nibh maximus ac. Praesent lacinia ullamcorper nisi
+			a accumsan. Vivamus mi leo, pulvinar in enim vitae, mattis tincidunt nisi.
+			Cras aliquet nisl vitae est malesuada, ut tempus ipsum fringilla. Sed
+			tristique sit amet elit nec volutpat. Suspendisse potenti. Praesent eget
+			arcu erat. Nullam mattis nisl lectus, in ultrices tortor facilisis ut.
+			Phasellus vitae aliquam sapien.
+		</p>
+		<p>
+			Donec egestas, mauris in suscipit egestas, massa lectus sodales nibh, eget
+			gravida augue tortor eget augue. Morbi aliquet volutpat leo, in
+			scelerisque turpis sagittis nec. Sed eget accumsan ex. Integer tincidunt
+			malesuada ipsum non sollicitudin. Duis venenatis mattis felis. Ut nibh
+			lectus, ornare quis risus eget, laoreet facilisis urna. Nulla cursus
+			pulvinar sapien vitae ultricies. Curabitur ante risus, pulvinar ac arcu
+			sit amet, vehicula commodo diam. Sed fringilla fringilla feugiat. Nullam
+			sodales, ante tincidunt interdum sagittis, metus ante congue nunc, quis
+			fermentum ex sem eu est. In volutpat urna nec urna dictum viverra. Sed
+			iaculis id quam id dictum. Sed non risus eget velit pellentesque
+			venenatis. Mauris lorem ligula, molestie vitae convallis eget, porttitor
+			sit amet purus. Aliquam tempus blandit sem nec porttitor. Maecenas at urna
+			ut erat pretium accumsan.
+		</p>
+		<p>
+			Aliquam vitae leo ac sem euismod pulvinar. Phasellus in pellentesque erat.
+			Duis eget pulvinar arcu, vitae lacinia tellus. In semper ex rhoncus lectus
+			vulputate, at molestie justo varius. Maecenas consectetur ultricies ipsum
+			vel interdum. Duis ac leo quis metus hendrerit fermentum ut at mi. Nam
+			auctor tortor eget nunc lacinia, vel ornare eros posuere. Sed sed lacinia
+			elit. Suspendisse potenti. Aenean id urna tellus. Nullam ullamcorper magna
+			sed lectus viverra tristique. In nec tempus dui. Ut placerat porta lorem
+			malesuada dapibus. Nunc leo lorem, hendrerit semper aliquet non, feugiat
+			ac tortor. Donec egestas vitae sapien quis fermentum. Sed id lacus sem.
+		</p>
+		<p>
+			Nunc bibendum ultrices nunc, vitae suscipit sem bibendum eget. In sapien
+			nisl, dignissim id tincidunt ac, tincidunt eu sapien. Fusce consectetur
+			erat quis vehicula mollis. Duis bibendum, ligula non condimentum feugiat,
+			arcu nulla sagittis purus, in finibus neque dolor id neque. Maecenas
+			accumsan consectetur aliquet. Mauris et risus malesuada, ultrices felis
+			ut, imperdiet ante. Fusce placerat neque ac lectus mattis, vitae pulvinar
+			mauris hendrerit. Praesent sed fermentum nibh.
+		</p>
+		<p>
+			Nulla egestas egestas massa, vitae facilisis nisl mollis in. Vestibulum
+			tincidunt turpis cursus tellus eleifend suscipit et molestie odio. Integer
+			ac congue enim. Aenean eget hendrerit purus, sit amet hendrerit mi. Donec
+			pharetra sodales mauris, finibus pretium quam. Cras at congue lorem. Donec
+			tristique ullamcorper mattis. Donec a faucibus purus. Quisque egestas est
+			at lorem ullamcorper, sit amet placerat purus eleifend. Cras lobortis elit
+			orci, egestas condimentum lorem commodo eget. Etiam sollicitudin ex id
+			lectus sagittis, vitae iaculis massa feugiat.
+		</p>
+		<p>
+			Aenean non vestibulum odio. Curabitur sodales sapien sed enim dapibus
+			vehicula. Donec malesuada ac dui a malesuada. Aliquam sodales erat dui, ut
+			placerat quam ullamcorper cursus. Vivamus lobortis ornare tortor, eget
+			tempus justo finibus sodales. Curabitur eleifend interdum libero, vitae
+			bibendum tortor consectetur et. Nam sed ipsum feugiat, fringilla elit et,
+			faucibus quam. Sed iaculis nec justo non semper. Aenean dapibus feugiat
+			accumsan.
+		</p>
+		<p>
+			Pellentesque volutpat est ac ex lacinia, at viverra risus bibendum.
+			Maecenas sit amet ligula suscipit, condimentum ante vitae, malesuada
+			nulla. Sed tincidunt, neque dapibus lacinia aliquet, turpis tellus
+			consequat mi, et tincidunt turpis justo maximus nibh. Donec mollis, ex sit
+			amet eleifend dictum, ex neque accumsan nunc, eget faucibus nunc nisi non
+			ex. Donec varius mi ac sapien gravida pulvinar. Quisque sollicitudin eget
+			ipsum vel interdum. Pellentesque finibus sollicitudin porttitor. Phasellus
+			ornare interdum est eget placerat. Phasellus fermentum dui eros, vel
+			ultricies urna convallis at. Aliquam non risus massa. Ut eleifend mauris
+			nec orci auctor, vel aliquet ligula mollis. Maecenas nec augue mauris.
+		</p>
+		<p>
+			Aliquam orci leo, finibus vitae leo ut, mattis hendrerit nunc. Curabitur
+			tempor tortor ante, fermentum faucibus enim malesuada vel. Donec varius
+			lobortis faucibus. Nunc a libero leo. Pellentesque tempus non dui sit amet
+			gravida. Aliquam erat volutpat. Sed nibh nunc, dictum ut metus eu,
+			ullamcorper gravida lorem. Sed semper bibendum sapien. Pellentesque nec
+			malesuada neque, et dictum augue. Vestibulum eget tempus quam. Praesent
+			varius elementum convallis. Nullam porttitor laoreet ante, at imperdiet
+			est. Etiam in fringilla orci. Praesent consectetur lacinia feugiat.
+		</p>
 	</body>
 </html>

--- a/01/web-client/article.html
+++ b/01/web-client/article.html
@@ -16,6 +16,7 @@
 			}
 		</style>
 	</head>
+
 	<body>
 		<p>
 			Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi vestibulum

--- a/01/web-client/main.ts
+++ b/01/web-client/main.ts
@@ -4,20 +4,16 @@ function countWords(paragraphElement: HTMLElement) {
 	return (paragraphElement.textContent.match(/\S+/g) ?? []).length;
 }
 // get references to our paragraph elements
-const paragraphElements = Array.from(
-	document.getElementsByTagName('p')
-);
+const paragraphElements = Array.from(document.getElementsByTagName('p'));
+console.log('Words in the first paragraph:', countWords(paragraphElements[0])); // 115
 console.log(
-	countWords(paragraphElements[0])
-); // 24 words in the first paragraph
-console.log(
+	'Words in the whole article:',
 	paragraphElements.reduce(
-		(articleWordCount, paragraphElement) => (
-			articleWordCount + countWords(paragraphElement)
-		),
+		(articleWordCount, paragraphElement) =>
+			articleWordCount + countWords(paragraphElement),
 		0
 	)
-); // 122 words in the whole article
+); // 929
 
 // sample-02
 // nest text within a span element so we can use Element.getClientRects
@@ -40,19 +36,26 @@ paragraphElements.forEach(nestTextWithinSpanElement);
 // sample-03
 // we'll keep track of the position and progress of each line of text
 interface Line {
-	borderBox: DOMRect,
-	readingProgress: number[]
+	borderBox: DOMRect;
+	readingProgress: number[];
+	// not in article: visual marker element for this line
+	markerElement: HTMLDivElement;
 }
 // paragraphs have references to the concrete element and the abstract lines
 interface Paragraph {
-	element: HTMLElement,
-	lines: Line[]
+	element: HTMLElement;
+	lines: Line[];
 }
+
+// the original scroll position of the viewport; to be used to check
+// when line marker boxes are in view or not
+let originalViewportTop = 0;
+
 // create line references for a given paragraph element
 function createLines(paragraphElement: HTMLElement) {
 	// take some measurements
-	const
-		clientRects = Array.from(
+	originalViewportTop = window.visualViewport.pageTop;
+	const clientRects = Array.from(
 			paragraphElement.firstElementChild.getClientRects()
 		),
 		lineCount = clientRects.length,
@@ -60,27 +63,26 @@ function createLines(paragraphElement: HTMLElement) {
 		minLineWordCount = Math.floor(wordCount / lineCount);
 	// distribute the words evenly over the lines
 	let remainingWordCount = wordCount % lineCount;
-	return clientRects.map(
-		clientRect => {
-			let lineWordCount = minLineWordCount;
-			if (remainingWordCount) {
-				lineWordCount++;
-				remainingWordCount--;
-			}
-			return {
-				borderBox: clientRect,
-				readingProgress: [-lineWordCount]
-			};
+	return clientRects.map(clientRect => {
+		let lineWordCount = minLineWordCount;
+		if (remainingWordCount) {
+			lineWordCount++;
+			remainingWordCount--;
 		}
-	);
+
+		return {
+			borderBox: clientRect,
+			readingProgress: [-lineWordCount],
+			// not in the article: adds a visual representation of this line to the DOM and stores it here
+			markerElement: createLineMarker(paragraphElement, clientRect),
+		};
+	});
 }
 // map our paragraph elements to paragraphs
-const paragraphs = paragraphElements.map(
-	paragraphElement => ({
-		element: paragraphElement,
-		lines: createLines(paragraphElement)
-	})
-);
+const paragraphs = paragraphElements.map(paragraphElement => ({
+	element: paragraphElement,
+	lines: createLines(paragraphElement),
+}));
 
 // sample-04
 /*
@@ -101,41 +103,111 @@ function tryReadWord(lines: Line[]) {
 	}
 	// find the first line that is visible within the viewport
 	const readableLine = unfinishedLines.find(
-		line => (
-			line.borderBox.top > 0 &&
-			line.borderBox.bottom < window.innerHeight
-		)
+		line =>
+			line.borderBox.top + originalViewportTop >
+				window.visualViewport.pageTop &&
+			line.borderBox.top + originalViewportTop <
+				window.visualViewport.pageTop + window.innerHeight
 	);
 	// increment the progress array left to right if found
 	if (readableLine) {
 		const progress = readableLine.readingProgress;
+		/*
+		We'll start by marking the next word as having been read. First we'll
+		check the array's length. The progress array of a completely unread line
+		will contain only a single negatively-signed integer.
+		*/
 		if (progress.length === 1) {
+			/*
+			If that's the case we'll insert a 1 at the beginning of the array to
+			represent the word that we've just read since we're reading from left
+			to right.
+			*/
 			progress.unshift(1);
 		} else {
+			/*
+			If there is already more than one element in the array then we know
+			this line is partially read. Since we're reading from left to right we
+			know the first element is a positive integer so we just increment it
+			by one to represent the word that we've just read.
+			*/
 			progress[0]++;
 		}
+		/*
+		Next we'll check to see if we've finished reading this line by checking
+		the value of the negatively-signed integer in the second position of the
+		array.
+		*/
 		if (progress[1] === -1) {
+			/*
+			If it equals -1 then there was only one word left to read and we can
+			just remove it from the array.
+			*/
 			progress.splice(1, 1);
 		} else {
+			/*
+			Otherwise we'll increment the value which will decrease the count of
+			unread words by one since this is a negative number.
+			*/
 			progress[1]++;
 		}
 	}
+	updateLineMarkers(unfinishedLines);
 	return true;
 }
+
 // create an array of lines from the paragraphs
 const lines = paragraphs.reduce(
 	(lines, paragraph) => lines.concat(paragraph.lines),
 	[]
 );
 // set an interval to read a word every 200 ms (equal to 300 word per minute)
-const readingInterval = setInterval(
-	() => {
-		// attempt to read a word and stop the loop if we're done
-		if (
-			!tryReadWord(lines)
-		) {
-			clearInterval(readingInterval);
-		}
-	},
-	200
-);
+const readingInterval = setInterval(() => {
+	// attempt to read a word and stop the loop if we're done
+	if (!tryReadWord(lines)) {
+		clearInterval(readingInterval);
+	}
+}, 200);
+
+// ---- extra code to visualize the reading tracker progress, not included in the article samples ----
+// Creates a <div> element for the given DOMRect and and adds it to the given paragraph.
+function createLineMarker(paragraphElement: HTMLElement, lineRect: DOMRect) {
+	// side effect: make the paragraph the reference for absolute elements
+	paragraphElement.style.position = 'relative';
+	const paragraphRect = paragraphElement.getClientRects()[0];
+	const lineMarker = document.createElement('div');
+	lineMarker.setAttribute(
+		'style',
+		`
+		  top: ${lineRect.top - paragraphRect.top}px;
+		  height: ${lineRect.height}px;
+		  left: 0;
+		  position: absolute;
+		  box-shadow: lime 0px 0px 0px 2px inset;
+		  background-image: linear-gradient(to right, rgba(0, 255, 0, 0.5) 100%, transparent 100%);
+		`
+	);
+	// side effect: add visual line box to the paragraph
+	paragraphElement.appendChild(lineMarker);
+	return lineMarker;
+}
+
+// updates the visual state of the line marker elements in the given lines
+function updateLineMarkers(lines: Line[]) {
+	lines.forEach(line => {
+		// calculates the fraction of the line that was read
+		const lineProgress = line => {
+			const totalWords = line.readingProgress.reduce(
+				(progress, word) => progress + Math.abs(word),
+				0
+			);
+			const readWords = line.readingProgress.reduce(
+				(progress, word) => progress + word,
+				0
+			);
+			return readWords > 0 ? readWords / totalWords : 0;
+		};
+		line.markerElement.style.width =
+			line.markerElement.parentElement.clientWidth * lineProgress(line) + 'px';
+	});
+}

--- a/01/web-client/main.ts
+++ b/01/web-client/main.ts
@@ -106,7 +106,7 @@ function tryReadWord(lines: Line[]) {
 		line =>
 			line.borderBox.top + originalViewportTop >
 				window.visualViewport.pageTop &&
-			line.borderBox.top + originalViewportTop <
+			line.borderBox.bottom + originalViewportTop <
 				window.visualViewport.pageTop + window.innerHeight
 	);
 	// increment the progress array left to right if found

--- a/01/web-client/package-lock.json
+++ b/01/web-client/package-lock.json
@@ -1,0 +1,655 @@
+{
+  "name": "01",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@zeit/schemas": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@zeit/schemas/-/schemas-2.6.0.tgz",
+      "integrity": "sha512-uUrgZ8AxS+Lio0fZKAipJjAh415JyrOZowliZAzmnJSsf7piVL5w+G0+gFJ0KSu3QRhvui/7zuvpLz03YjXAhg==",
+      "dev": true
+    },
+    "accepts": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
+      "integrity": "sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==",
+      "dev": true,
+      "requires": {
+        "mime-types": "~2.1.24",
+        "negotiator": "0.6.2"
+      }
+    },
+    "ajv": {
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.3.tgz",
+      "integrity": "sha512-LqZ9wY+fx3UMiiPd741yB2pj3hhil+hQc8taf4o2QGRFpWgZ2V5C8HA165DY9sS3fJwsk7uT7ZlFEyC3Ig3lLg==",
+      "dev": true,
+      "requires": {
+        "fast-deep-equal": "^2.0.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      }
+    },
+    "ansi-align": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
+      "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
+      "dev": true,
+      "requires": {
+        "string-width": "^2.0.0"
+      }
+    },
+    "ansi-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+      "dev": true
+    },
+    "ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "requires": {
+        "color-convert": "^1.9.0"
+      }
+    },
+    "arch": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/arch/-/arch-2.2.0.tgz",
+      "integrity": "sha512-Of/R0wqp83cgHozfIYLbBMnej79U/SVGOOyuB3VVFv1NRM/PSFMK12x9KVtiYzJqmnU5WR2qp0Z5rHb7sWGnFQ==",
+      "dev": true
+    },
+    "arg": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-2.0.0.tgz",
+      "integrity": "sha512-XxNTUzKnz1ctK3ZIcI2XUPlD96wbHP2nGqkPKpvk/HNRlPveYrXIVSTk9m3LcqOgDPg3B1nMvdV/K8wZd7PG4w==",
+      "dev": true
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "boxen": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.3.0.tgz",
+      "integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
+      "dev": true,
+      "requires": {
+        "ansi-align": "^2.0.0",
+        "camelcase": "^4.0.0",
+        "chalk": "^2.0.1",
+        "cli-boxes": "^1.0.0",
+        "string-width": "^2.0.0",
+        "term-size": "^1.2.0",
+        "widest-line": "^2.0.0"
+      }
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "bytes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+      "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
+      "dev": true
+    },
+    "camelcase": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+      "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+      "dev": true
+    },
+    "chalk": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+      "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      }
+    },
+    "cli-boxes": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
+      "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM=",
+      "dev": true
+    },
+    "clipboardy": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/clipboardy/-/clipboardy-1.2.3.tgz",
+      "integrity": "sha512-2WNImOvCRe6r63Gk9pShfkwXsVtKCroMAevIbiae021mS850UkWPbevxsBz3tnvjZIEGvlwaqCPsw+4ulzNgJA==",
+      "dev": true,
+      "requires": {
+        "arch": "^2.1.0",
+        "execa": "^0.8.0"
+      },
+      "dependencies": {
+        "execa": {
+          "version": "0.8.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-0.8.0.tgz",
+          "integrity": "sha1-2NdrvBtVIX7RkP1t1J08d07PyNo=",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^5.0.1",
+            "get-stream": "^3.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
+          }
+        }
+      }
+    },
+    "color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
+    "compressible": {
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
+      "integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
+      "dev": true,
+      "requires": {
+        "mime-db": ">= 1.43.0 < 2"
+      }
+    },
+    "compression": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.3.tgz",
+      "integrity": "sha512-HSjyBG5N1Nnz7tF2+O7A9XUhyjru71/fwgNb7oIsEVHR0WShfs2tIS/EySLgiTe98aOK18YDlMXpzjCXY/n9mg==",
+      "dev": true,
+      "requires": {
+        "accepts": "~1.3.5",
+        "bytes": "3.0.0",
+        "compressible": "~2.0.14",
+        "debug": "2.6.9",
+        "on-headers": "~1.0.1",
+        "safe-buffer": "5.1.2",
+        "vary": "~1.1.2"
+      }
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "content-disposition": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
+      "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ=",
+      "dev": true
+    },
+    "cross-spawn": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+      "dev": true,
+      "requires": {
+        "lru-cache": "^4.0.1",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
+      }
+    },
+    "debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "dev": true
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "execa": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+      "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^5.0.1",
+        "get-stream": "^3.0.0",
+        "is-stream": "^1.1.0",
+        "npm-run-path": "^2.0.0",
+        "p-finally": "^1.0.0",
+        "signal-exit": "^3.0.0",
+        "strip-eof": "^1.0.0"
+      }
+    },
+    "fast-deep-equal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+      "dev": true
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true
+    },
+    "fast-url-parser": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/fast-url-parser/-/fast-url-parser-1.1.3.tgz",
+      "integrity": "sha1-9K8+qfNNiicc9YrSs3WfQx8LMY0=",
+      "dev": true,
+      "requires": {
+        "punycode": "^1.3.2"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+          "dev": true
+        }
+      }
+    },
+    "get-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+      "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+      "dev": true
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
+    },
+    "ini": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+      "dev": true
+    },
+    "is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "dev": true
+    },
+    "is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "dev": true
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
+    "json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
+    },
+    "lru-cache": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+      "dev": true,
+      "requires": {
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
+      }
+    },
+    "mime-db": {
+      "version": "1.44.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
+      "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==",
+      "dev": true
+    },
+    "mime-types": {
+      "version": "2.1.27",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
+      "integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
+      "dev": true,
+      "requires": {
+        "mime-db": "1.44.0"
+      }
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "minimist": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "dev": true
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
+    "negotiator": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
+      "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==",
+      "dev": true
+    },
+    "npm-run-path": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+      "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+      "dev": true,
+      "requires": {
+        "path-key": "^2.0.0"
+      }
+    },
+    "on-headers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
+      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
+      "dev": true
+    },
+    "p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+      "dev": true
+    },
+    "path-is-inside": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+      "dev": true
+    },
+    "path-key": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+      "dev": true
+    },
+    "path-to-regexp": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.2.1.tgz",
+      "integrity": "sha512-gu9bD6Ta5bwGrrU8muHzVOBFFREpp2iRkVfhBJahwJ6p6Xw20SjT0MxLnwkjOibQmGSYhiUnf2FLe7k+jcFmGQ==",
+      "dev": true
+    },
+    "prettier": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.1.2.tgz",
+      "integrity": "sha512-16c7K+x4qVlJg9rEbXl7HEGmQyZlG4R9AgP+oHKRMsMsuk8s+ATStlf1NpDqyBI1HpVyfjLOeMhH2LvuNvV5Vg==",
+      "dev": true
+    },
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+      "dev": true
+    },
+    "punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true
+    },
+    "range-parser": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
+      "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4=",
+      "dev": true
+    },
+    "rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "dev": true,
+      "requires": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      }
+    },
+    "registry-auth-token": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.2.tgz",
+      "integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
+      "dev": true,
+      "requires": {
+        "rc": "^1.1.6",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "registry-url": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
+      "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
+      "dev": true,
+      "requires": {
+        "rc": "^1.0.1"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
+    },
+    "serve": {
+      "version": "11.3.2",
+      "resolved": "https://registry.npmjs.org/serve/-/serve-11.3.2.tgz",
+      "integrity": "sha512-yKWQfI3xbj/f7X1lTBg91fXBP0FqjJ4TEi+ilES5yzH0iKJpN5LjNb1YzIfQg9Rqn4ECUS2SOf2+Kmepogoa5w==",
+      "dev": true,
+      "requires": {
+        "@zeit/schemas": "2.6.0",
+        "ajv": "6.5.3",
+        "arg": "2.0.0",
+        "boxen": "1.3.0",
+        "chalk": "2.4.1",
+        "clipboardy": "1.2.3",
+        "compression": "1.7.3",
+        "serve-handler": "6.1.3",
+        "update-check": "1.5.2"
+      }
+    },
+    "serve-handler": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/serve-handler/-/serve-handler-6.1.3.tgz",
+      "integrity": "sha512-FosMqFBNrLyeiIDvP1zgO6YoTzFYHxLDEIavhlmQ+knB2Z7l1t+kGLHkZIDN7UVWqQAmKI3D20A6F6jo3nDd4w==",
+      "dev": true,
+      "requires": {
+        "bytes": "3.0.0",
+        "content-disposition": "0.5.2",
+        "fast-url-parser": "1.1.3",
+        "mime-types": "2.1.18",
+        "minimatch": "3.0.4",
+        "path-is-inside": "1.0.2",
+        "path-to-regexp": "2.2.1",
+        "range-parser": "1.2.0"
+      },
+      "dependencies": {
+        "mime-db": {
+          "version": "1.33.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+          "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==",
+          "dev": true
+        },
+        "mime-types": {
+          "version": "2.1.18",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+          "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+          "dev": true,
+          "requires": {
+            "mime-db": "~1.33.0"
+          }
+        }
+      }
+    },
+    "shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "dev": true,
+      "requires": {
+        "shebang-regex": "^1.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+      "dev": true
+    },
+    "signal-exit": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
+      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
+      "dev": true
+    },
+    "string-width": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "dev": true,
+      "requires": {
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
+      }
+    },
+    "strip-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^3.0.0"
+      }
+    },
+    "strip-eof": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+      "dev": true
+    },
+    "strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+      "dev": true
+    },
+    "supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "requires": {
+        "has-flag": "^3.0.0"
+      }
+    },
+    "term-size": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
+      "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
+      "dev": true,
+      "requires": {
+        "execa": "^0.7.0"
+      }
+    },
+    "typescript": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.5.tgz",
+      "integrity": "sha512-ywmr/VrTVCmNTJ6iV2LwIrfG1P+lv6luD8sUJs+2eI9NLGigaN+nUQc13iHqisq7bra9lnmUSYqbJvegraBOPQ==",
+      "dev": true
+    },
+    "update-check": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/update-check/-/update-check-1.5.2.tgz",
+      "integrity": "sha512-1TrmYLuLj/5ZovwUS7fFd1jMH3NnFDN1y1A8dboedIDt7zs/zJMo6TwwlhYKkSeEwzleeiSBV5/3c9ufAQWDaQ==",
+      "dev": true,
+      "requires": {
+        "registry-auth-token": "3.3.2",
+        "registry-url": "3.1.0"
+      }
+    },
+    "uri-js": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.0.tgz",
+      "integrity": "sha512-B0yRTzYdUCCn9n+F4+Gh4yIDtMQcaJsmYBDsTSG8g/OejKBodLQ2IHfN3bM7jUsRXndopT7OIXWdYqc1fjmV6g==",
+      "dev": true,
+      "requires": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
+      "dev": true
+    },
+    "which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
+      "requires": {
+        "isexe": "^2.0.0"
+      }
+    },
+    "widest-line": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.1.tgz",
+      "integrity": "sha512-Ba5m9/Fa4Xt9eb2ELXt77JxVDV8w7qQrH0zS/TWSJdLyAwQjWoOzpzj5lwVftDz6n/EOu3tNACS84v509qwnJA==",
+      "dev": true,
+      "requires": {
+        "string-width": "^2.1.1"
+      }
+    },
+    "yallist": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+      "dev": true
+    }
+  }
+}

--- a/01/web-client/package.json
+++ b/01/web-client/package.json
@@ -1,0 +1,21 @@
+{
+	"name": "01",
+	"version": "1.0.0",
+	"description": "Sample code for \"How Readup Knows Whether or Not You’ve Read an Article\"",
+	"main": "article.js",
+	"scripts": {
+		"build": "npx tsc --project tsconfig.json",
+		"start": "npm run build && npx serve"
+	},
+	"author": "Jeff Camera",
+	"devDependencies": {
+		"prettier": "^2.1.2",
+		"serve": "^11.3.2",
+		"typescript": "^4.0.5"
+	},
+	"prettier": {
+		"useTabs": true,
+		"arrowParens": "avoid",
+		"singleQuote": true
+	}
+}

--- a/01/web-client/tsconfig.json
+++ b/01/web-client/tsconfig.json
@@ -1,10 +1,7 @@
 {
-	"compilerOptions": {
-		"lib": [
-			"DOM",
-			"DOM.Iterable",
-			"ES2020"
-		],
-		"target": "ES2020"
-	}
+  "compilerOptions": {
+    "lib": ["DOM", "DOM.Iterable", "ES2020"],
+    "target": "ES2020"
+  },
+  "include": ["*.ts"]
 }


### PR DESCRIPTION
This PR makes it a bit easier for someone who clones the project to run the example in their browser.

It adds an NPM configuration for the web client so dependencies can be installed, with a [prettier](https://prettier.io/docs/en/options.html) config that approximates the original formatting. Still, my VSCode editor did remove some of the original formatting.

It also changes the sample code slightly to add a simplified visualization of the reading tracker (debug mode) and to support articles that exceed the viewport + scrolling.

More and longer paragraphs were added to the article so one can try to see what happens when you scroll, skim & pause.

Thanks for this working sample code @jacamera! Really interesting stuff.
